### PR TITLE
Verify that object is defined before trying to read its properties

### DIFF
--- a/libraries/HybridObjectsWebFrontend.js
+++ b/libraries/HybridObjectsWebFrontend.js
@@ -227,8 +227,7 @@ exports.uploadInfoText = function (parm, objectLookup, objectExp, knownObjects, 
         if(typeof objectExp[objectName] === 'undefined' ||
            Object.getOwnPropertyNames(objectExp[objectName].objectValues).length == 0) {
             console.log("error loading the data");
-        }
-        else {
+        } else {
             var uploadInfoTexttempArray = objectExp[objectName].objectLinks;
             var uploadInfoTexttempArrayValue = objectExp[objectName].objectValues;
             

--- a/libraries/HybridObjectsWebFrontend.js
+++ b/libraries/HybridObjectsWebFrontend.js
@@ -222,12 +222,16 @@ exports.uploadInfoText = function (parm, objectLookup, objectExp, knownObjects, 
     });
 
     function GetAndSendData() {
-    var d = new Date();
-
-        var uploadInfoTexttempArray = objectExp[objectName].objectLinks;
-        var uploadInfoTexttempArrayValue = objectExp[objectName].objectValues;
-
-        if(Object.getOwnPropertyNames(uploadInfoTexttempArrayValue).length != 0) {
+        var d = new Date();
+        
+        if(typeof objectExp[objectName] === 'undefined' ||
+           Object.getOwnPropertyNames(objectExp[objectName].objectValues).length == 0) {
+            console.log("error loading the data");
+        }
+        else {
+            var uploadInfoTexttempArray = objectExp[objectName].objectLinks;
+            var uploadInfoTexttempArrayValue = objectExp[objectName].objectValues;
+            
             // add the variables
            var infoCount = 0;
            var jsonVariables = [];
@@ -294,10 +298,7 @@ exports.uploadInfoText = function (parm, objectLookup, objectExp, knownObjects, 
             if(sockets) {
                 sockets.emit("getSomeData",updatedMonitor);
             }
-        } else {
-            console.log("error loading the data");
         }
-
     }
 
      realoadInterfaceTimeout = setInterval(GetAndSendData, 100);


### PR DESCRIPTION
Fixes the crash that occurs when viewing the `/info/{thing}` page (right out of the box).

I haven't read through much of the code yet, please advise if this should be fixed elsewhere instead.
