### PR TITLE
Inject script tag into all HTML files

### DIFF
--- a/server.js
+++ b/server.js
@@ -767,7 +767,7 @@ function objectWebServer() {
         var urlArray = req.originalUrl.split("/");
 
         console.log(urlArray);
-        if ((req.method === "GET" && urlArray[2] !== "dataPointInterfaces") && (req.url.slice(-1) === "/" || urlArray[3] === "index.html" || urlArray[3] === "index.htm")) {
+        if ((req.method === "GET" && urlArray[2] !== "dataPointInterfaces") && (req.url.slice(-1) === "/" || urlArray[3].match(/\.html?$/))) {
 
             var fileName = __dirname + "/objects" + req.url;
 


### PR DESCRIPTION
Expands injection to include all html files present in the directory
instead of just index.htm and index.html. Useful if people attempt
to create a multi-page object.
